### PR TITLE
Potential fix for issue #5 - document duplication

### DIFF
--- a/Macros/Convert Tabs to Spaces, Strip whitespace, save.tmMacro
+++ b/Macros/Convert Tabs to Spaces, Strip whitespace, save.tmMacro
@@ -2,58 +2,56 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>commands</key>
-	<array>
-		<dict>
-			<key>command</key>
-			<string>changeTabsToSpaces:</string>
-		</dict>
-		<dict>
-			<key>argument</key>
-			<dict>
-				<key>beforeRunningCommand</key>
-				<string>nop</string>
-				<key>command</key>
-				<string>perl -pe 's/[\t ]+$//g'</string>
-				<key>fallbackInput</key>
-				<string>document</string>
-				<key>input</key>
-				<string>selection</string>
-				<key>name</key>
-				<string>Remove Trailing Spaces in Document / Selection</string>
-				<key>output</key>
-				<string>replaceSelectedText</string>
-				<key>uuid</key>
-				<string>0F8C1F78-6E4C-11D9-91AF-000D93589AF6</string>
-			</dict>
-			<key>command</key>
-			<string>executeCommandWithOptions:</string>
-		</dict>
-		<dict>
-			<key>argument</key>
-			<dict>
-				<key>beforeRunningCommand</key>
-				<string>saveActiveFile</string>
-				<key>input</key>
-				<string>none</string>
-				<key>name</key>
-				<string>Save Document</string>
-				<key>output</key>
-				<string>discard</string>
-				<key>uuid</key>
-				<string>5BBEE531-FECE-4A3F-ABF3-A7FE0C10A6AE</string>
-			</dict>
-			<key>command</key>
-			<string>executeCommandWithOptions:</string>
-		</dict>
-	</array>
-	<key>keyEquivalent</key>
-	<string>@s</string>
-	<key>name</key>
-	<string>Convert Tabs to Spaces, Strip whitespace, save</string>
-	<key>scope</key>
-	<string>- text.html.markdown</string>
-	<key>uuid</key>
-	<string>D6844EF1-342B-46D9-A687-CB402F7F4209</string>
+  <key>commands</key>
+  <array>
+    <dict>
+      <key>command</key>
+      <string>changeTabsToSpaces:</string>
+    </dict>
+    <dict>
+      <key>argument</key>
+      <dict>
+        <key>beforeRunningCommand</key>
+        <string>nop</string>
+        <key>command</key>
+        <string>perl -pe 's/[\t ]+$//g'</string>
+        <key>input</key>
+        <string>document</string>
+        <key>name</key>
+        <string>Remove Trailing Spaces in Document / Selection</string>
+        <key>output</key>
+        <string>replaceDocument</string>
+        <key>uuid</key>
+        <string>0F8C1F78-6E4C-11D9-91AF-000D93589AF6</string>
+      </dict>
+      <key>command</key>
+      <string>executeCommandWithOptions:</string>
+    </dict>
+    <dict>
+      <key>argument</key>
+      <dict>
+        <key>beforeRunningCommand</key>
+        <string>saveActiveFile</string>
+        <key>input</key>
+        <string>none</string>
+        <key>name</key>
+        <string>Save Document</string>
+        <key>output</key>
+        <string>discard</string>
+        <key>uuid</key>
+        <string>5BBEE531-FECE-4A3F-ABF3-A7FE0C10A6AE</string>
+      </dict>
+      <key>command</key>
+      <string>executeCommandWithOptions:</string>
+    </dict>
+  </array>
+  <key>keyEquivalent</key>
+  <string>@s</string>
+  <key>name</key>
+  <string>Convert Tabs to Spaces, Strip whitespace, save</string>
+  <key>scope</key>
+  <string>- text.html.markdown</string>
+  <key>uuid</key>
+  <string>D6844EF1-342B-46D9-A687-CB402F7F4209</string>
 </dict>
 </plist>


### PR DESCRIPTION
I think I've actually removed the functionality to strip spaces from only a selection rather than the full document, but that's functionality I've never wanted or needed, so it works for me. 

Understand completely if you'd rather keep that functionality and ignore this fork.
